### PR TITLE
Remove text block and expand chat

### DIFF
--- a/templates-main/durable-chat-template/public/index.html
+++ b/templates-main/durable-chat-template/public/index.html
@@ -31,14 +31,7 @@
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
     <div class="container" style="width: 95%; height: 100%">
       <div class="row" style="height: 100%">
-        <div class="one-third column" style="margin-top: 25%">
-          <h4><b>Chat</b>, powered by Durable Objects</h4>
-          <p>
-            This chat room is hosted in a single Durable Object, running in one
-            process in one machine in one location, very close to the users.
-          </p>
-        </div>
-        <div class="two-thirds column" id="root"></div>
+        <div class="twelve columns" id="root"></div>
       </div>
     </div>
 

--- a/templates-main/durable-chat-template/public/styles.css
+++ b/templates-main/durable-chat-template/public/styles.css
@@ -9,6 +9,8 @@ html {
 
 .chat {
   padding-top: 40px;
+  width: 100%;
+  height: 100%;
 }
 
 #root {
@@ -18,6 +20,7 @@ html {
   justify-content: flex-end;
   overflow-y: auto;
   height: 100%;
+  width: 100%;
   /* padding: 10px; */
 }
 
@@ -48,4 +51,11 @@ html {
 
 .my-input-text::placeholder {
   color: #ccc;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+  .chat {
+    padding-top: 20px;
+  }
 }


### PR DESCRIPTION
Remove the text block on the left side of the page and expand the chat to full width and height.

* Delete the `<div class="one-third column" style="margin-top: 25%">` element and its contents in `templates-main/durable-chat-template/public/index.html`.
* Change the `class` attribute of the `<div class="two-thirds column" id="root">` element to `class="twelve columns"` in `templates-main/durable-chat-template/public/index.html`.
* Update the `.chat` class in `templates-main/durable-chat-template/public/styles.css` to set `width: 100%` and `height: 100%`.
* Update the `#root` element in `templates-main/durable-chat-template/public/styles.css` to set `width: 100%` and `height: 100%`.
* Add CSS media queries in `templates-main/durable-chat-template/public/styles.css` to adjust the layout based on device size.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Derpenstein69/derp-chat/pull/2?shareId=06707c5c-d891-4dbd-b4b6-342624730e93).