### PR TITLE
Implement OpenAuth in durable-chat-template

### DIFF
--- a/templates-main/durable-chat-template/src/server/index.ts
+++ b/templates-main/durable-chat-template/src/server/index.ts
@@ -11,6 +11,10 @@ import { CloudflareStorage } from "@openauthjs/openauth/storage/cloudflare";
 import { PasswordAdapter } from "@openauthjs/openauth/adapter/password";
 import { PasswordUI } from "@openauthjs/openauth/ui/password";
 import { object, string } from "valibot";
+import { GoogleAdapter } from "@openauthjs/openauth/adapter/google";
+import { GithubAdapter } from "@openauthjs/openauth/adapter/github";
+import { AppleAdapter } from "@openauthjs/openauth/adapter/apple";
+import { DiscordAdapter } from "@openauthjs/openauth/adapter/discord";
 
 import type { ChatMessage, Message } from "../shared";
 
@@ -195,6 +199,26 @@ export default {
             },
           }),
         ),
+        google: GoogleAdapter({
+          clientID: process.env.GOOGLE_CLIENT_ID!,
+          clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+          scopes: ["profile", "email"],
+        }),
+        github: GithubAdapter({
+          clientID: process.env.GITHUB_CLIENT_ID!,
+          clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+          scopes: ["user:email"],
+        }),
+        apple: AppleAdapter({
+          clientID: process.env.APPLE_CLIENT_ID!,
+          clientSecret: process.env.APPLE_CLIENT_SECRET!,
+          scopes: ["name", "email"],
+        }),
+        discord: DiscordAdapter({
+          clientID: process.env.DISCORD_CLIENT_ID!,
+          clientSecret: process.env.DISCORD_CLIENT_SECRET!,
+          scopes: ["identify", "email"],
+        }),
       },
       theme: {
         title: "myAuth",


### PR DESCRIPTION
Integrate OpenAuth client into the frontend and configure authentication flow.

* **Client Integration:**
  - Import `createClient` from `@openauthjs/openauth/client` in `templates-main/durable-chat-template/src/client/index.tsx`.
  - Initialize OpenAuth client with `clientID`, `issuer`, and `redirect_uri`.
  - Implement authentication flow to handle authorization code exchange and store access tokens in local storage.

* **Server Configuration:**
  - Import Google, GitHub, Apple, and Discord adapters from `@openauthjs/openauth/adapter` in `templates-main/durable-chat-template/src/server/index.ts`.
  - Configure each provider with required credentials and add to the `providers` object in the `authorizer` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Derpenstein69/derp-chat/pull/5?shareId=3df9759f-056c-4a1e-b746-ab0af75a587e).