### PR TITLE
Replace valibot with Zod for validation

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,10 +9,13 @@
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
+import prettier from "eslint-plugin-prettier";
+import configPrettier from "eslint-config-prettier";
 
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.strictTypeChecked,
+  configPrettier,
   {
     languageOptions: {
       parserOptions: {
@@ -30,6 +33,7 @@ export default tseslint.config(
        */
       "@typescript-eslint/restrict-template-expressions": "off",
       "@typescript-eslint/no-empty-object-type": "off",
+      "prettier/prettier": "error",
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "preview_image_url": "https://imagedelivery.net/wSMYJvS3Xw-n339CbDyDIA/da00d330-9a3b-40a2-e6df-b08813fb7200/public"
   },
   "dependencies": {
+    "@openauthjs/openauth": "0.2.5",
     "eventsource-parser": "3.0.0",
     "nanoid": "5.0.9",
     "partyserver": "0.0.57",
@@ -24,22 +25,21 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router": "7.0.2",
-    "@openauthjs/openauth": "0.2.5",
-    "valibot": "^1.0.0-beta.9"
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "4.20241216.0",
-    "@types/react": "18.3.12",
-    "@types/react-dom": "18.3.1",
-    "esbuild": "0.24.0",
-    "typescript": "5.6.3",
-    "wrangler": "3.97.0",
-    "eslint": "^8.0.0",
-    "prettier": "^2.0.0",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.1",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
+    "esbuild": "^0.24.0",
+    "eslint": "^8.0.0",
     "eslint-config-prettier": "^8.0.0",
-    "eslint-plugin-prettier": "^4.0.0"
+    "eslint-plugin-prettier": "^4.0.0",
+    "prettier": "^2.0.0",
+    "typescript": "^5.6.3",
+    "wrangler": "^3.97.0"
   },
   "scripts": {
     "check": "tsc --project src/client && tsc --project src/server && wrangler --experimental-json-config deploy --dry-run",

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -17,7 +17,7 @@ import {
 } from "react-router";
 import { nanoid } from "nanoid";
 import { createClient } from "@openauthjs/openauth/client";
-import { object, string, validate } from "valibot";
+import { z } from "zod";
 
 import { names, type ChatMessage, type Message } from "../shared";
 
@@ -27,9 +27,9 @@ const client = createClient({
   issuer: "https://auth.myserver.com",
 });
 
-// Define a schema for input validation using valibot
-const messageSchema = object({
-  content: string().min(1, "Content cannot be empty"),
+// Define a schema for input validation using Zod
+const messageSchema = z.object({
+  content: z.string().min(1, "Content cannot be empty"),
 });
 
 /**
@@ -309,9 +309,9 @@ function App(): JSX.Element {
           ) as HTMLInputElement;
 
           // Validate input data
-          const validationResult = validate(messageSchema, { content: content.value });
+          const validationResult = messageSchema.safeParse({ content: content.value });
           if (!validationResult.success) {
-            alert(validationResult.errors[0].message);
+            alert(validationResult.error.errors[0].message);
             return;
           }
 


### PR DESCRIPTION
Replace `valibot` with `Zod` for validation and update ESLint configuration.

* **Validation Changes:**
  - Replace `valibot` with `Zod` in `src/client/index.tsx`.
  - Update import statement to use `Zod` instead of `valibot`.
  - Modify validation logic to use `Zod` for `messageSchema`.

* **ESLint Configuration:**
  - Include `eslint-config-prettier` and `eslint-plugin-prettier` in `eslint.config.mjs`.
  - Disable ESLint rules that conflict with Prettier.
  - Run Prettier as an ESLint rule.

* **Dependencies:**
  - Remove `valibot` from `package.json`.
  - Add `Zod` as a dependency in `package.json`.
  - Adjust other dependencies and devDependencies for consistency.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Derpenstein69/derp-chat/pull/36?shareId=a4247597-c648-44a9-b3af-994c5299ba0d).